### PR TITLE
Entferne Notiz in Referenzen

### DIFF
--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -13,23 +13,6 @@ Dieser Abschnitt enthält Quellenangaben, die ganz oder teilweise im Curriculum 
 This section contains references that are cited in the curriculum.
 // end::EN[]
 
-[NOTE]
-====
-Aufbau eines Eintrags-Ankers:
-```
-- [[[label,Text der erscheint]]]
-```
-ACHTUNG: Die Labels dürfen nur Buchstaben beinhalten, keine Zahlen oder Sonderzeichen
-
-= = =
-
-Structure of an anchor:
-```
-- [[[label,text that will be shown]]]
-```
-ATTENTION: labels have to be non-numeric.
-====
-
 
 **A**
 


### PR DESCRIPTION
Die entsprechende Notiz ist imho im fertigen Dokument überflüssig.